### PR TITLE
Add enricher to support inserting the challenge dice icon in user-entered text.

### DIFF
--- a/module/ac2d20.mjs
+++ b/module/ac2d20.mjs
@@ -17,6 +17,8 @@ import { DialogD6 } from './roller/dialogD6.js'
 import DieACChallenge from './roller/challengeDie.js'
 //Settings
 import { registerSettings } from './settings.js';
+// Text Enrichers
+import { registerEnrichers } from './enrichers.mjs';
 //Momentum
 import { MomentumTracker } from './app/momentum-tracker.mjs'
 
@@ -65,6 +67,9 @@ Hooks.once('init', async function () {
 
     // Register custom system settings
     registerSettings();
+
+	// Register text enrichers.
+	registerEnrichers();
 
     return preloadHandlebarsTemplates();
 });

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -1,0 +1,18 @@
+export function registerEnrichers() {
+	CONFIG.TextEditor.enrichers = [
+		...CONFIG.TextEditor.enrichers,
+		{
+			pattern: /@(s(tress)?|c(hallenge)?)/gim,
+			enricher: async (match, options) => {
+				const i = document.createElement('i');
+				i.className = 'cthl-cthulhu';
+
+				// Adjust positioning slightly to align better with text.
+				i.style.position = 'relative';
+				i.style.top = '0.2em';
+
+				return i;
+			},
+		},
+	];
+}


### PR DESCRIPTION
Supports `@s`, `@stress`, `@c`, and `@challenge` notation.

Input:
![image](https://user-images.githubusercontent.com/124085763/221953018-b838dc6b-03f3-49b3-9a11-4afb1e0d605e.png)

Result:
![image](https://user-images.githubusercontent.com/124085763/221953068-76ff0364-88a2-4291-bf93-93cd83530775.png)
